### PR TITLE
adding venv and requirements to make life easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
+pip-selfcheck.json
+.vscode/
+include/
 build/
 develop-eggs/
 dist/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Market data is obtained using the Alpha Vantage API through a a small API client
 	- `share_price` - price per share
 	- `commission` - commission (if any)
 
+- `source bin/activate` to activate the virtualenv
 - `python server.py`
 - Go to the addres shown in your terminal window to view the summary table
 

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -1,0 +1,2 @@
+flask
+alphavantage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+alphavantage==0.0.11
+certifi==2018.4.16
+chardet==3.0.4
+click==6.7
+Flask==1.0.2
+foil==0.2.7
+idna==2.7
+iso8601==0.1.12
+itsdangerous==0.24
+Jinja2==2.10
+MarkupSafe==1.0
+pytz==2018.5
+PyYAML==3.13
+requests==2.19.1
+urllib3==1.23
+Werkzeug==0.14.1


### PR DESCRIPTION
@blattus highly recommend venv if sharing b/w multiple engineers. virtualenv + requirements.txt helps standardize dev environments and the local packages installed.

added a line to README.md to explain how to activate it.